### PR TITLE
Support for disabling the control and support for use in non-ARC environments.

### DIFF
--- a/DFColorWell/DFColorWell.h
+++ b/DFColorWell/DFColorWell.h
@@ -89,7 +89,7 @@ IB_DESIGNABLE
  
  This property is KVO observable.
  */
-@property(retain) NSColor *color;
+@property(strong) NSColor *color;
 
 ///--------------------------------------------------
 /// @name Customising the colors shown in the popover
@@ -101,7 +101,7 @@ IB_DESIGNABLE
  During initialisation this property is set to an internal delegate which provide default colour matrix view for the popover.
  
  */
-@property(assign) IBOutlet id <DFColorWellDelegate> delegate;
+@property(weak) IBOutlet id <DFColorWellDelegate> delegate;
 
 #pragma mark - Drawing convenience methods
 

--- a/DFColorWell/DFColorWell.h
+++ b/DFColorWell/DFColorWell.h
@@ -89,7 +89,7 @@ IB_DESIGNABLE
  
  This property is KVO observable.
  */
-@property NSColor *color;
+@property(retain) NSColor *color;
 
 ///--------------------------------------------------
 /// @name Customising the colors shown in the popover
@@ -101,7 +101,7 @@ IB_DESIGNABLE
  During initialisation this property is set to an internal delegate which provide default colour matrix view for the popover.
  
  */
-@property IBOutlet id <DFColorWellDelegate> delegate;
+@property(assign) IBOutlet id <DFColorWellDelegate> delegate;
 
 #pragma mark - Drawing convenience methods
 

--- a/DFColorWell/DFColorWell.m
+++ b/DFColorWell/DFColorWell.m
@@ -130,6 +130,8 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
 
 @property NSPopover *popover;
 
+@property DFColorGridViewDefaultDelegate *defaultDelegate;
+
 @end
 
 @implementation DFColorWell
@@ -175,8 +177,9 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
     if (self.color == nil) {
         self.color = [NSColor colorWithCalibratedRed:1.0 green:1.0 blue:1.0 alpha:1.0];
     }
-    
-    self.delegate = [[DFColorGridViewDefaultDelegate alloc] init];
+	
+    self.defaultDelegate = [[DFColorGridViewDefaultDelegate alloc] init];
+	self.delegate = self.defaultDelegate;
 }
 
 #pragma mark - Tooltips


### PR DESCRIPTION
In ARC, the properties default to "strong" ownership. However, in non-ARC, they default to "assign" ownership and Xcode warns about the missing ownership declarations.

To get rid of the warnings I've added the missing declarations to the header files.

Also, per convention, delegate properties should be weak in Objective-C to avoid retain cycles. To make the default delegate survive, I've added another internal property.
