### PR TITLE
Fixed crash if color picker left open when control is deallocated.

### DIFF
--- a/DFColorWell/DFColorWell.h
+++ b/DFColorWell/DFColorWell.h
@@ -91,6 +91,18 @@ IB_DESIGNABLE
  */
 @property NSColor *color;
 
+///---------------------------------
+/// @name Using a gesture recognizer
+///---------------------------------
+
+
+/** Whether to use a gesture recognizer instead of a mouse up handler.
+ 
+ The mouse event doesn't work inside a table view.  Not sure why, but using a gesture recognizer works around the issue.
+ */
+@property BOOL useGestureRecognizer;
+
+
 ///--------------------------------------------------
 /// @name Customising the colors shown in the popover
 ///--------------------------------------------------

--- a/DFColorWell/DFColorWell.h
+++ b/DFColorWell/DFColorWell.h
@@ -89,7 +89,7 @@ IB_DESIGNABLE
  
  This property is KVO observable.
  */
-@property NSColor *color;
+@property(strong) NSColor *color;
 
 ///---------------------------------
 /// @name Using a gesture recognizer
@@ -113,7 +113,7 @@ IB_DESIGNABLE
  During initialisation this property is set to an internal delegate which provide default colour matrix view for the popover.
  
  */
-@property IBOutlet id <DFColorWellDelegate> delegate;
+@property(weak) IBOutlet id <DFColorWellDelegate> delegate;
 
 #pragma mark - Drawing convenience methods
 

--- a/DFColorWell/DFColorWell.m
+++ b/DFColorWell/DFColorWell.m
@@ -132,6 +132,8 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
 
 @property NSPopover *popover;
 
+@property BOOL isInterfaceBuilder;
+
 @end
 
 @implementation DFColorWell
@@ -181,14 +183,21 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
     self.delegate = [[DFColorGridViewDefaultDelegate alloc] init];
 }
 
+- (void)prepareForInterfaceBuilder {
+    
+    self.isInterfaceBuilder = YES;
+}
+
 - (void)dealloc {
     
-    NSColorPanel *panel = [NSColorPanel sharedColorPanel];
-    
-    if (panel) {
-        [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowWillCloseNotification object:panel];
+    if (!self.isInterfaceBuilder) {
+        NSColorPanel *panel = [NSColorPanel sharedColorPanel];
         
-        [panel close];
+        if (panel) {
+            [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowWillCloseNotification object:panel];
+            
+            [panel close];
+        }
     }
 }
 

--- a/DFColorWell/DFColorWell.m
+++ b/DFColorWell/DFColorWell.m
@@ -186,9 +186,6 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
     if (panel) {
         [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowWillCloseNotification object:panel];
         
-        panel.target = nil;
-        panel.action = NULL;
-        
         [panel close];
     }
 }

--- a/DFColorWell/DFColorWell.m
+++ b/DFColorWell/DFColorWell.m
@@ -125,6 +125,8 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
 
 @property NSBezierPath *controlOuterBorderPath;
 
+@property NSClickGestureRecognizer *clickRecognizer;
+
 // Popover and content view controller
 @property DFColorGridView *colorGridView;
 
@@ -529,6 +531,43 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
 }
 
 
+#pragma mark - Gesture handling
+
+- (BOOL) useGestureRecognizer {
+    
+    return self.clickRecognizer != nil;
+}
+
+- (void) setUseGestureRecognizer:(BOOL)useGestureRecognizer {
+    
+    if (useGestureRecognizer == self.useGestureRecognizer) {
+        return;
+    }
+    
+    if (self.clickRecognizer) {
+        [self removeGestureRecognizer:self.clickRecognizer];
+        self.clickRecognizer = nil;
+    } else {
+        self.clickRecognizer = [[NSClickGestureRecognizer alloc] initWithTarget:self action:@selector(clickGestureHandler:)];
+        [self addGestureRecognizer:self.clickRecognizer];
+    }
+}
+
+- (void) clickGestureHandler:(NSGestureRecognizer *)recognizer {
+    
+    if (recognizer.state == NSGestureRecognizerStateRecognized) {
+        
+        NSPoint locationInView = [recognizer locationInView:self];
+        
+        if (NSPointInRect(locationInView, [self _controlColorSwatchFrame])) {
+            [self _handleMouseUpInColorRect];
+        } else if (NSPointInRect(locationInView, [self _controlButtonFrame])){
+            [self _handleMouseUpInButtonRect];
+        }
+    }
+}
+
+
 #pragma mark - Mouse tracking
 
 - (void) mouseEntered:(NSEvent *)theEvent {
@@ -607,7 +646,6 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
     [self beginDraggingSessionWithItems:@[item] event:theEvent source:source];
     
 }
-
 
 #pragma mark - Mouse Clicking
 

--- a/DFColorWell/DFColorWell.m
+++ b/DFColorWell/DFColorWell.m
@@ -154,6 +154,16 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
         panel.target = nil;
         panel.action = NULL;
     }
+    
+    if (!self.isInterfaceBuilder) {
+        NSColorPanel *panel = [NSColorPanel sharedColorPanel];
+        
+        if (panel) {
+            [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowWillCloseNotification object:panel];
+            
+            [panel close];
+        }
+    }
 }
 
 - (void) awakeFromNib {
@@ -206,19 +216,6 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
 - (void)prepareForInterfaceBuilder {
     
     self.isInterfaceBuilder = YES;
-}
-
-- (void)dealloc {
-    
-    if (!self.isInterfaceBuilder) {
-        NSColorPanel *panel = [NSColorPanel sharedColorPanel];
-        
-        if (panel) {
-            [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowWillCloseNotification object:panel];
-            
-            [panel close];
-        }
-    }
 }
 
 #pragma mark - Tooltips
@@ -879,6 +876,8 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
         return;
     }
     
+    BOOL settingDefault = !_color;
+    
     [self willChangeValueForKey:@"color"];
     _color = color;
     [self setNeedsDisplay:YES];
@@ -894,7 +893,7 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
     }
     
     // Set the control's target/action
-    if ([self.target respondsToSelector:self.action]) {
+    if (!settingDefault && [self.target respondsToSelector:self.action]) {
         [NSApp sendAction:self.action to:self.target from:self];
     }
     

--- a/DFColorWell/DFColorWell.m
+++ b/DFColorWell/DFColorWell.m
@@ -179,6 +179,20 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
     self.delegate = [[DFColorGridViewDefaultDelegate alloc] init];
 }
 
+- (void)dealloc {
+    
+    NSColorPanel *panel = [NSColorPanel sharedColorPanel];
+    
+    if (panel) {
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowWillCloseNotification object:panel];
+        
+        panel.target = nil;
+        panel.action = NULL;
+        
+        [panel close];
+    }
+}
+
 #pragma mark - Tooltips
 
 - (NSString*) view:(NSView *)view stringForToolTip:(NSToolTipTag)tag point:(NSPoint)point userData:(void *)data {

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Any improvements welcomed.
 Things that need adding & improvements
 --------------------------------------
 
-* I wrote this on rMBP running OSX 10.10 so there may be some retina specific code which does not look good on other screens.
-
 * Want to add the ability to display custom views in the popover (from a user specified content view controller), this will enable users to design their own layout of colour cells etc.
 
 Usage
@@ -30,7 +28,7 @@ Usage
 
    ![Setting the placeholder intrinsic content size](http://i.imgur.com/5X0KuA5.png)
 
-4. Implement all the **required** delegate methods which fills the pop over with different colours:
+4. **Optionally** Implement the delegate methods which fills the pop over with different colours. If you do not implement these delegate methods an internal delegate object will be created which provide the default colours shown above in the main screenshot.
 
 ```
     - (NSUInteger) numberOfRowsInColorWell:(DFColorWell*)colorWell;


### PR DESCRIPTION
For example when switching to another view.  The color picker is now
automatically closed, which is a better experience, and avoids the
crash.
