### PR TITLE
Fixed race condition when setting delegate in awakeFromNib

### DIFF
--- a/DFColorWell/DFColorWell.m
+++ b/DFColorWell/DFColorWell.m
@@ -179,7 +179,9 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
     }
 	
     self.defaultDelegate = [[DFColorGridViewDefaultDelegate alloc] init];
-	self.delegate = self.defaultDelegate;
+    if (self.delegate == nil) {
+        self.delegate = self.defaultDelegate;
+    }
 }
 
 #pragma mark - Tooltips


### PR DESCRIPTION
When a NIB is instantiated, in some cases a race condition occurs where the `awakeFromNib` of a controller is called before the `awakeFromNib` of DFColorWell. If that happens, DFColorWell overwrites the delegate set by the controller. Guard against this by checking whether the delegate has already been set.
