### PR TITLE
Update the color panel when setting a color

### DIFF
--- a/DFColorWell/DFColorWell.m
+++ b/DFColorWell/DFColorWell.m
@@ -740,7 +740,9 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
         panel.showsAlpha = YES;
         panel.target = self;
         panel.action = @selector(handleColorPanelColorSelectionAction:);
+        self.isUpdatingColorPanel = YES;
         panel.color = self.color;
+        self.isUpdatingColorPanel = NO;
         [panel orderFront:nil];
         
         /* Capture the close of the color panel. */
@@ -811,6 +813,11 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
     
     
     if (color == nil) {
+        return;
+    }
+    
+    if ([_color isEqual:color]) {
+        // Don't re-apply the same color to prevent event loops.
         return;
     }
     


### PR DESCRIPTION
Currently, when the control's color is changed the color panel is not in sync with the control unless the color change was initiated via the color panel. For example, open the color panel and then select a color from the color grid. The control reflects the choice, but the color panel does not.

This merge request fixes that. Updating the color now also sets the color panel's color if the control is the "owner" of the color panel. Since that in turn triggers an action, we need to ignore that while updating the color panel to avoid triggering KVO and our action twice.
