### PR TITLE
Fix a minor static analyzer warning

### DIFF
--- a/DFColorWell/DFColorWell.m
+++ b/DFColorWell/DFColorWell.m
@@ -213,7 +213,7 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
             return @"Click to show more colours or show your own.";
         }
     }
-    return nil;
+    return @"";
 }
 
 #pragma mark - Control private drawing methods


### PR DESCRIPTION
The tooltip delegate method must not return `nil`. So just return an empty string instead.