### PR TITLE
Prevent KVO from being triggered twice

### DIFF
--- a/DFColorWell/DFColorWell.m
+++ b/DFColorWell/DFColorWell.m
@@ -823,10 +823,8 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
         return;
     }
     
-    [self willChangeValueForKey:@"color"];
     _color = color;
     [self setNeedsDisplay:YES];
-    [self didChangeValueForKey:@"color"];
     
     if ([self isColorPanelTarget]) {
         // Update the panel as well so the control and panel are in sync. We need to ignore actions

--- a/DFColorWell/DFColorWell.m
+++ b/DFColorWell/DFColorWell.m
@@ -811,6 +811,13 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
 
 @synthesize color = _color;
 
++ (BOOL)automaticallyNotifiesObserversOfColor
+{
+	// We're calling `willChangeValueForKey:` and `didChangeValueForKey:` manually, don't let
+	// Cocoa generate these for us.
+	return NO;
+}
+
 - (void) setColor:(NSColor *)color {
     
     
@@ -823,7 +830,10 @@ static void * kDFButtonTooltipArea = &kDFButtonTooltipArea;
         return;
     }
     
+	[self willChangeValueForKey:NSStringFromSelector(@selector(color))];
     _color = color;
+	[self didChangeValueForKey:NSStringFromSelector(@selector(color))];
+
     [self setNeedsDisplay:YES];
     
     if ([self isColorPanelTarget]) {


### PR DESCRIPTION
When setting the color property, observers get notified twice. We need to explicitly tell Cocoa that we're calling `willChangeValueForKey:` and `didChangeValueForKey:` manually to prevent the automatic notification of observers.

I also tried to simply remove the calls to `willChangeValueForKey:` and `didChangeValueForKey:` but that triggered KVO even when the color was not actually updated.